### PR TITLE
Fix visibility and typo on Cache._?item

### DIFF
--- a/raspador/cache.py
+++ b/raspador/cache.py
@@ -5,20 +5,21 @@ from collections import deque
 class Cache(object):
     def __init__(self, max_length=0):
         self.max_length = max_length
-        self.items = deque()
+        self._items = deque()
 
     def __len__(self):
-        return len(self.items)
+        return len(self._items)
 
     def append(self, item):
-        self.items.append(item)
+        self._items.append(item)
         if self.max_length:
-            while len(self.items) > self.max_length:
-                self.items.popleft()
+            while len(self._items) > self.max_length:
+                self._items.popleft()
 
-    def itens(self):
-        return self.items
+    @property
+    def items(self):
+        return self._items
 
     def consume(self):
-        while self.items:
-            yield self.items.popleft()
+        while self._items:
+            yield self._items.popleft()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,7 +12,7 @@ class Test_Cache(unittest.TestCase):
         self.cache.append(2)
         self.cache.append(3)
         self.cache.append(4)
-        self.assertEqual(list(self.cache.itens()), [2, 3, 4])
+        self.assertEqual(list(self.cache.items), [2, 3, 4])
 
     def test_should_consume_cache(self):
         self.cache.append(1)


### PR DESCRIPTION
Fixed a typo on `itens` function, I changed the `items` variable of `Cache` to `_itens` and renamed old method to a property named `items`.
